### PR TITLE
Add location of UI website to README

### DIFF
--- a/www/README.md
+++ b/www/README.md
@@ -43,6 +43,12 @@ cd app
 http-server -a localhost -p 8000
 ```
 
+See the dashboard UI in your web browser at:
+
+```
+http://localhost:8000/
+```
+
 ### Configuration
 #### Configuration settings
 A json file can be used by `gulp` to automatically create angular constants. This is useful for setting per environment variables such as api endpoints.


### PR DESCRIPTION
Add that the development web server is at localhost:8000 in  `www/README.md`
